### PR TITLE
Bug fix while transofrming sizes

### DIFF
--- a/lib/epav.py
+++ b/lib/epav.py
@@ -7,6 +7,7 @@ import json
 import smtlib
 import extras
 import md5
+import re
 from pyfancy import *
 from functools import reduce
 import preprocessor_types
@@ -133,15 +134,18 @@ def preProcessBytes(line):
     return False
 
 def toscaRawValueToSMTCorrectType(attributeName, value, MainData):
+## This whole function should be implemented with REs!!! 
+## Doing a quick and dirty bug fix for transforming 10MB into ten megabytes but not transforming LoadBalancer into Load Bytes...  
+
   # if is ip
   if len(str(value).split('.')) is 4:
     MainData["valueTypes"][attributeName] = "ip"
     return IP2Int(value)
   
   # if is memory size 100 GB
-  sizes = ["B", "KB", "MB", "GB", "TB", "PB"]
-  for k in sizes:
-    if k in str(value):
+  sizes = [re.compile("^\s*\d+\s*B\s*$"), re.compile("^\s*\d+\s*MB\s*$"), re.compile("^\s*\d+\s*GB\s*$"), re.compile("^\s*\d+\s*TB\s*$"), re.compile("^\s*\d+\s*PB\s*$")]
+  for sz in sizes:
+    if sz.match(str(value)):
       MainData["valueTypes"][attributeName] = "size"
       return bin2Dec(value)
 


### PR DESCRIPTION
While transforming "sizes" into integer representations strings like "LoadBalancer" got transformed. 

Solution, transform only matching values, i.e., those that are composed of an integer number and the string sizes ("B", "GB", etc.); proper regular expressions were used. 

2do: implement all transformations with regular expressions, more surprises can come otherwise.